### PR TITLE
audio player reloads and autoplays on source change

### DIFF
--- a/src/MusicPlayer.js
+++ b/src/MusicPlayer.js
@@ -49,6 +49,7 @@ export default class MusicPlayer extends Component {
 
   selectSong(key) {
     this.setState({ count: key });
+    this.waveformReload();
   }
 
   playerClick(type) {
@@ -57,6 +58,13 @@ export default class MusicPlayer extends Component {
     } else if (type === "prev_song" && this.state.count > 0) {
       this.setState({ count: this.state.count - 1 });
     }
+    this.waveformReload();
+  }
+
+  waveformReload () {
+    this.refs.waveform.pause();
+    this.refs.waveform.load();
+    this.refs.waveform.play();
   }
 
   render() {
@@ -69,7 +77,7 @@ export default class MusicPlayer extends Component {
             {songRepo[this.state.count].songLength}
           </span>
         </div>
-        <audio className="waveform" preload="auto" controls>
+        <audio className="waveform" preload="auto" controls ref="waveform">
           <source src={songRepo[this.state.count].path} type="audio/mp3" />
         </audio>
         <div className="player_buttons">


### PR DESCRIPTION
The problem was indeed that the DOM audio object doesn't care what it's source is after that source is loaded, so the solution's pretty simple: get the object, and (re)load its source.  I made it play when that's done, too.

It seems to work pretty reliably from a few tests, but I'm pretty sure that, as is, I set up a race condition. You probably want to at least set a short timeout on around waveformReload() or, better yet, have it test that react has finished updating the DOM before the calls to pause, load, and play.